### PR TITLE
fix(python-bridge): Update outdated dependencies for compatibility

### DIFF
--- a/python-bridge/readme.md
+++ b/python-bridge/readme.md
@@ -1,21 +1,38 @@
-# Connect Bridgeapp for Python
+# ProtoPie Connect Bridge App for Python
 
-> Python based program. You must use `python3`.
+A Python-based program to interact with ProtoPie Connect via Socket.IO messages. This allows you to send messages from your Python script to ProtoPie and receive messages sent from ProtoPie.
 
-# How to run
+Requires Python 3.8 or newer.
 
-## Install
+## Setup
 
-```sh
-pip3 install -r requirements.txt
-```
+It is highly recommended to use a Python virtual environment to manage dependencies.
 
-## Run
+1.  **Create and activate a virtual environment (Optional but recommended):**
+    ```bash
+    # Create environment (only needed once)
+    python -m venv venv
 
-```sh
-python3 client.py
-```
+    # Activate environment (do this every time you work on the project)
+    # On Linux/macOS:
+    source venv/bin/activate
+    # On Windows (Command Prompt/PowerShell):
+    # venv\Scripts\activate
+    ```
 
-# Licenses
+2.  **Install dependencies:**
+    Navigate to this directory (`python-bridge`) in your terminal and run:
+    ```bash
+    pip install -r requirements.txt
+    ```
 
-@ Studio XID
+## How to Run
+
+1.  Ensure ProtoPie Connect is running and listening (usually at `http://localhost:9981`).
+2.  Run the client script from this directory:
+    ```bash
+    python client.py
+    ```
+3.  The script will connect to ProtoPie Connect.
+4.  You can send messages to ProtoPie Connect by typing a `messageId` and `value` when prompted in the terminal.
+5.  Messages received from ProtoPie Connect (via the "Send to Bridge App" response) will be printed in the terminal.

--- a/python-bridge/requirements.txt
+++ b/python-bridge/requirements.txt
@@ -1,12 +1,6 @@
-bidict==0.21.2
-certifi==2020.12.5
-chardet==4.0.0
-greenlet==0.4.17
-idna==2.10
-msgpack==1.0.0
-pynvim==0.4.2
-python-engineio==3.14.2
-python-socketio==4.6.1
-requests==2.25.1
-six==1.15.0
-urllib3==1.26.4
+# Required packages for the ProtoPie Connect Python Bridge
+# Install using: pip install -r requirements.txt
+# Python 3.8+ recommended
+
+python-socketio[client]>=5.0.0 
+msgpack>=1.0.2  


### PR DESCRIPTION
**Context:**

This PR addresses issues reported by users attempting to set up and run the `python-bridge` example application. The existing `requirements.txt` file pins dependencies to very old versions (circa late 2020/early 2021), notably `greenlet==0.4.17`.

**Problem:**

These outdated dependencies cause several problems on modern development environments:

1.  **Installation Failure:** `pip install -r requirements.txt` fails on current Python versions (e.g., Python 3.11, 3.12) because `greenlet==0.4.17` cannot be built successfully. (As confirmed by internal testing, this old version is unmaintained and incompatible).
2.  **Runtime Errors:** Even if workarounds are used (like forcing Python 3.10 or manually installing newer specific packages), the mix of old and potentially new dependencies can lead to runtime errors.
3.  **Poor Developer Experience:** Requires users to perform complex workarounds instead of a standard `pip install`.

**Solution:**

This PR updates the `python-bridge` example to use more recent and maintained versions of its dependencies, ensuring compatibility with current Python versions (tested on Python 3.8+).

**Changes:**

1.  **Updated `requirements.txt`:** Replaced outdated, strictly pinned dependencies with `python-socketio[client]>=5.0.0` and `msgpack>=1.0.2` for compatibility with Python 3.8+.
2.  **Updated `README.md`:** Revised Python version recommendation, added instructions for using virtual environments (`venv`), and simplified setup/run steps.